### PR TITLE
Avoid "Undefined index" notices

### DIFF
--- a/wordpress-plugin/includes/admin.php
+++ b/wordpress-plugin/includes/admin.php
@@ -73,7 +73,7 @@ class Infinite_Scroll_Admin {
 	 */
 	function send_to_editor( $args ) {
 		global $wpdb;
-		if (isset($GLOBALS['HTTP_POST_FILES']['async-upload'])){
+		if ( isset( $GLOBALS['HTTP_POST_FILES'] ) && isset( $GLOBALS['HTTP_POST_FILES']['async-upload'] ) ) {
 			if ( $args['errors'] !== null )
 				return $args;
 				


### PR DESCRIPTION
When in debug mode plugin breaks media uploader and any ajax/json request due to many "Undefined index" notices